### PR TITLE
Potential fix for code scanning alert no. 2: Server-side request forgery

### DIFF
--- a/app/deletebutton.jsx
+++ b/app/deletebutton.jsx
@@ -15,7 +15,7 @@ export default function DeleteButton({id, fetchFunction}) {
         if (typeof window !== 'undefined' && typeof localStorage !== 'undefined') {
             const defaultProfileId = localStorage.getItem('defaultProfileId');
             const validProfiles = await fetch('/api/profiles').then((response) => response.json());
-            if (!validProfiles.includes(defaultProfileId)) {
+            if (!validProfiles.some(profile => profile.id === defaultProfileId)) {
                 alert('The active profile is not valid. Please reselect your profile in the Profile Manager.');
                 return;
             }

--- a/app/deletebutton.jsx
+++ b/app/deletebutton.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from 'react';
+import { isValidProfileId } from '../utils/validation';
 
 export default function DeleteButton({id, fetchFunction}) {
     const [authorProfileId, setAuthorProfileId] = useState('');
@@ -21,6 +22,11 @@ export default function DeleteButton({id, fetchFunction}) {
             }
 
             if (authorProfileId !== defaultProfileId) {
+                if (!isValidProfileId(defaultProfileId, validProfiles)) {
+                    alert('Invalid profile ID detected. Please ensure your active profile is valid.');
+                    return;
+                }
+
                 const profile = await fetch(`/api/profiles/${defaultProfileId}`).then((response) => response.json());
                 if (!profile.moderator){
                     alert(`Cannot delete this post; you must be the post's author or a moderator to delete a post. If you are able to delete this post, please select the correct profile in the Profile Manager.`);

--- a/app/deletebutton.jsx
+++ b/app/deletebutton.jsx
@@ -13,8 +13,15 @@ export default function DeleteButton({id, fetchFunction}) {
 
     async function deletePost() {
         if (typeof window !== 'undefined' && typeof localStorage !== 'undefined') {
-            if (authorProfileId !== localStorage.getItem('defaultProfileId')) {
-                const profile = await fetch(`/api/profiles/${localStorage.getItem('defaultProfileId')}`).then((response) => response.json());
+            const defaultProfileId = localStorage.getItem('defaultProfileId');
+            const validProfiles = await fetch('/api/profiles/valid').then((response) => response.json());
+            if (!validProfiles.includes(defaultProfileId)) {
+                alert('The active profile is not valid. Please reselect your profile in the Profile Manager.');
+                return;
+            }
+
+            if (authorProfileId !== defaultProfileId) {
+                const profile = await fetch(`/api/profiles/${defaultProfileId}`).then((response) => response.json());
                 if (!profile.moderator){
                     alert(`Cannot delete this post; you must be the post's author or a moderator to delete a post. If you are able to delete this post, please select the correct profile in the Profile Manager.`);
                     return;

--- a/app/deletebutton.jsx
+++ b/app/deletebutton.jsx
@@ -14,7 +14,7 @@ export default function DeleteButton({id, fetchFunction}) {
     async function deletePost() {
         if (typeof window !== 'undefined' && typeof localStorage !== 'undefined') {
             const defaultProfileId = localStorage.getItem('defaultProfileId');
-            const validProfiles = await fetch('/api/profiles/valid').then((response) => response.json());
+            const validProfiles = await fetch('/api/profiles').then((response) => response.json());
             if (!validProfiles.includes(defaultProfileId)) {
                 alert('The active profile is not valid. Please reselect your profile in the Profile Manager.');
                 return;

--- a/app/deletebutton.jsx
+++ b/app/deletebutton.jsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState } from 'react';
-import { isValidProfileId } from '../utils/validation';
 
 export default function DeleteButton({id, fetchFunction}) {
     const [authorProfileId, setAuthorProfileId] = useState('');
@@ -20,10 +19,10 @@ export default function DeleteButton({id, fetchFunction}) {
                 alert('The active profile is not valid. Please reselect your profile in the Profile Manager.');
                 return;
             }
-
+            
             if (authorProfileId !== defaultProfileId) {
-                if (!isValidProfileId(defaultProfileId, validProfiles)) {
-                    alert('Invalid profile ID detected. Please ensure your active profile is valid.');
+                if (!validProfiles.some(profile => profile.id === defaultProfileId)) {
+                    alert('The active profile is not valid. Please reselect your profile in the Profile Manager.');
                     return;
                 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/jaherron/MessageBoard/security/code-scanning/2](https://github.com/jaherron/MessageBoard/security/code-scanning/2)

To mitigate the SSRF vulnerability:
1. Restrict the possible values for the `defaultProfileId` retrieved from `localStorage`. Validate this value against a server-defined allowlist or verify it server-side before constructing the URL.
2. Ensure that no user-controlled input is directly used in the hostname or path of an outgoing request without validation.

The best fix involves fetching a list of valid profile IDs from the server, checking if the `defaultProfileId` exists in this list, and only then proceeding with the request. This can be implemented by adding a validation step before using `localStorage.getItem('defaultProfileId')` in the fetch call.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
